### PR TITLE
EBF: allow_other_host: true on paypal express redirect

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -34,8 +34,7 @@ module Spree
       begin
         pp_response = provider.set_express_checkout(pp_request)
         if pp_response.success?
-          redirect_to payment_method.
-            express_checkout_url(pp_response, useraction: 'commit', allow_other_host: true)
+          redirect_to payment_method.express_checkout_url(pp_response, useraction: 'commit'), allow_other_host: true
         else
           flash[:error] = Spree.t('flash.generic_error', scope: 'paypal', reasons: pp_response.errors.map(&:long_message).join(" "))
           redirect_to checkout_state_path(:payment)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PayPal Express Checkout redirect handling to ensure proper configuration of checkout parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->